### PR TITLE
ADD: Support for Logging in Julia Standard Library

### DIFF
--- a/src/InfrastructureModels.jl
+++ b/src/InfrastructureModels.jl
@@ -11,18 +11,30 @@ if VERSION < v"0.7.0-"
     import Compat: occursin
     import Compat: Nothing
     import Compat: round
+
+    # Create our module level logger (this will get precompiled)
+    const LOGGER = getlogger(@__MODULE__)
+    # Register the module level logger at runtime so that folks can access the logger via `getlogger(InfrastructureModels)`
+    # NOTE: If this line is not included then the precompiled `Infrastructure.LOGGER` won't be registered at runtime.
+    __init__() = Memento.register(LOGGER)
+
+    macro warn(message)
+        :(Memento.warn(LOGGER, $(esc(message))))
+    end
+
+    macro debug(message)
+        :(Memento.debug(LOGGER, $(esc(message))))
+    end
+
+    macro info(message)
+        :(Memento.info(LOGGER, $(esc(message))))
+    end
 end
 
 if VERSION > v"0.7.0-"
     using LinearAlgebra
+    using Logging
 end
-
-# Create our module level logger (this will get precompiled)
-const LOGGER = getlogger(@__MODULE__)
-
-# Register the module level logger at runtime so that folks can access the logger via `getlogger(InfrastructureModels)`
-# NOTE: If this line is not included then the precompiled `Infrastructure.LOGGER` won't be registered at runtime.
-__init__() = Memento.register(LOGGER)
 
 include("core/data.jl")
 include("core/relaxation_scheme.jl")

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -4,10 +4,10 @@ export update_data!
 function update_data!(data::Dict{String,Any}, new_data::Dict{String,Any})
     if haskey(data, "per_unit") && haskey(new_data, "per_unit")
         if data["per_unit"] != new_data["per_unit"]
-            error("update_data requires datasets in the same units, try make_per_unit and make_mixed_units")
+            throw(error("update_data requires datasets in the same units, try make_per_unit and make_mixed_units"))
         end
     else
-        warn(LOGGER, "running update_data with data that does not include per_unit field, units may be incorrect")
+        @warn "running update_data with data that does not include per_unit field, units may be incorrect"
     end
     _update_data!(data, new_data)
 end
@@ -36,15 +36,15 @@ ismultinetwork(data::Dict{String,Any}) = (haskey(data, "multinetwork") && data["
 function replicate(sn_data::Dict{String,Any}, count::Int; global_keys::Set{String} = Set{String}())
     @assert count > 0
     if ismultinetwork(sn_data)
-        error("replicate can only be used on single networks")
+        throw(error("replicate can only be used on single networks"))
     end
 
     if length(global_keys) <= 0
-        warn(LOGGER, "deprecation warning, calls to replicate should explicitly specify a set of global_keys")
+        @warn "deprecation warning, calls to replicate should explicitly specify a set of global_keys"
         # old default
         for (k,v) in sn_data
              if !(typeof(v) <: Dict)
-                warn(LOGGER, "adding global key $(k)")
+                @warn "adding global key $(k)"
                 push!(global_keys, k)
              end
         end
@@ -92,7 +92,7 @@ component_table(data::Dict{String,Any}, component::String, field::String) = comp
 function _component_table(data::Dict{String,Any}, component::String, fields::Vector{String})
     comps = data[component]
     if !_iscomponentdict(comps)
-        error(LOGGER, "$(component) does not appear to refer to a component list")
+        throw(error("$(component) does not appear to refer to a component list"))
     end
 
     items = []
@@ -123,7 +123,7 @@ end
 "prints the text summary for a data dictionary to IO"
 function summary(io::IO, data::Dict{String,Any}; float_precision::Int = 3)
     if ismultinetwork(data)
-        error("summary does not yet support multinetwork data")
+        throw(error("summary does not yet support multinetwork data"))
     end
 
     component_types_order = Dict(

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -17,7 +17,7 @@ function arrays_to_dicts!(data::Dict{String,Any})
                 if !(haskey(dict, key))
                     dict[key] = item
                 else
-                    warn(LOGGER, "skipping component $(item["index"]) from the $(k) table because a component with the same id already exists")
+                    @warn "skipping component $(item["index"]) from the $(k) table because a component with the same id already exists"
                 end
             end
             data[k] = dict

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -38,13 +38,13 @@ function parse_matlab_string(data_string::String; extended=false)
             function_name = value
         elseif occursin("=",line)
             if struct_name != nothing && !occursin("$(struct_name).", line)
-                warn(LOGGER, "assignments are expected to be made to \"$(struct_name)\" but given: $(line)")
+                @warn "assignments are expected to be made to \"$(struct_name)\" but given: $(line)"
             end
 
             if occursin("[", line)
                 matrix_dict = parse_matlab_matrix(data_lines, index)
                 matlab_dict[matrix_dict["name"]] = matrix_dict["data"]
-                if haskey(matrix_dict, "column_names") 
+                if haskey(matrix_dict, "column_names")
                     column_names[matrix_dict["name"]] = matrix_dict["column_names"]
                 end
                 index = index + matrix_dict["line_count"]-1
@@ -61,7 +61,7 @@ function parse_matlab_string(data_string::String; extended=false)
                 matlab_dict[name] = value
             end
         else
-            warn(LOGGER, "Matlab parser skipping the following line:\n  $(line)")
+            @warn "Matlab parser skipping the following line:\n  $(line)"
         end
 
         index += 1
@@ -183,7 +183,7 @@ function parse_matlab_data(lines, index, start_char, end_char)
         if columns < 0
             columns = length(row_items)
         elseif columns != length(row_items)
-            error(LOGGER, "matrix parsing error, inconsistent number of items in each row\n$(row)")
+            throw(error("matrix parsing error, inconsistent number of items in each row\n$(row)"))
         end
     end
 
@@ -201,10 +201,10 @@ function parse_matlab_data(lines, index, start_char, end_char)
         column_names_string = replace(column_names_string, "%column_names%" => "")
         column_names = split(column_names_string)
         if length(matrix[1]) != length(column_names)
-            error(LOGGER, "column name parsing error, data rows $(length(matrix[1])), column names $(length(column_names)) \n$(column_names)")
+            throw(error("column name parsing error, data rows $(length(matrix[1])), column names $(length(column_names)) \n$(column_names)"))
         end
         if any([column_name == "index" for column_name in column_names])
-            error(LOGGER, "column name parsing error, \"index\" is a reserved column name \n$(column_names)")
+            throw(error("column name parsing error, \"index\" is a reserved column name \n$(column_names)"))
         end
         matrix_dict["column_names"] = column_names
     end
@@ -288,7 +288,7 @@ function check_type(typ, value)
             value = parse(typ, value)
             return value
         catch e
-            error(LOGGER, "parsing error, the matlab string \"$(value)\" can not be parsed to $(typ) data")
+            throw(error("parsing error, the matlab string \"$(value)\" can not be parsed to $(typ) data"))
             rethrow(e)
         end
     else
@@ -296,7 +296,7 @@ function check_type(typ, value)
             value = typ(value)
             return value
         catch e
-            error(LOGGER, "parsing error, the matlab value $(value) of type $(typeof(value)) can not be parsed to $(typ) data")
+            throw(error("parsing error, the matlab value $(value) of type $(typeof(value)) can not be parsed to $(typ) data"))
             rethrow(e)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,18 +1,19 @@
 using InfrastructureModels
-using Memento
 using JSON
 using Compat
 
 if VERSION > v"0.7.0-"
     using Test
+    using Logging
+    Logging.disable_logging(Logging.Warn)
 end
 
 if VERSION < v"0.7.0-"
+    using Memento
     using Base.Test
+    setlevel!(getlogger(InfrastructureModels), "error")
 end
 
-# Suppress warnings during testing.
-setlevel!(getlogger(InfrastructureModels), "error")
 
 include("common.jl")
 


### PR DESCRIPTION
Adds support for the Logging library within Julia v0.7/v1.0's standard
library. Support for Memento will be maintained until Julia v0.6 support
is dropped, due to no logging available in the Base before Julia v0.7.
Removal of Memento has been made easier by separating Memento-
based tests into their own blocks, and by creating temporary macros
upon load of InfrastructureModels in VERSION < v"0.7.0-".

All unit tests were converted, no unit tests were dropped in this
addition.

TODO:

- [ ] Package-level logging (separate logger for package)