### PR TITLE
Support for Model Integrality Relaxation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ InfrastructureModels.jl Change Log
 ==================================
 
 ### Staged
-- nothing
+- Add support for `relax_integrality` in `optimize_model!`
 
 ### v0.5.3
 - Add generic `constraint_bounds_on_off` function.

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -214,8 +214,16 @@ end
 
 
 ""
-function optimize_model!(aim::AbstractInfrastructureModel; optimizer=nothing, solution_processors=[])
+function optimize_model!(aim::AbstractInfrastructureModel; relax_integrality=false, optimizer=nothing, solution_processors=[])
     start_time = time()
+
+    if relax_integrality
+        try
+            JuMP.relax_integrality(aim.model)
+        catch
+            Memento.warn(_LOGGER, "the relax_integrality feature requires JuMP v0.21.4, update to gain access to this feature")
+        end
+    end
 
     if optimizer != nothing
         if aim.model.moi_backend.state == _MOI.Utilities.NO_OPTIMIZER
@@ -234,7 +242,7 @@ function optimize_model!(aim::AbstractInfrastructureModel; optimizer=nothing, so
     try
         solve_time = _MOI.get(aim.model, _MOI.SolveTime())
     catch
-        Memento.warn(_LOGGER, "the given optimizer does not provide the SolveTime() attribute, falling back on @timed.  This is not a rigorous timing value.");
+        Memento.warn(_LOGGER, "the given optimizer does not provide the SolveTime() attribute, falling back on @timed.  This is not a rigorous timing value.")
     end
     Memento.debug(_LOGGER, "JuMP model optimize time: $(time() - start_time)")
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -242,7 +242,7 @@ end
 
 @testset "helper functions - instantiate_model, optimize_model!, sol" begin
     mim = instantiate_model(generic_network_data, MyInfrastructureModel, build_my_model, ref_add_core!, gn_global_keys, ref_extensions=[ref_ext_comp_stat!])
-    result = optimize_model!(mim, relax_integrality=true, optimizer=ipopt_solver)
+    result = optimize_model!(mim, optimizer=ipopt_solver)
     solution = result["solution"]
 
     @test solution["glb"] == 4.56

--- a/test/base.jl
+++ b/test/base.jl
@@ -132,6 +132,30 @@ function build_my_model(aim::MyAbstractInfrastructureModel)
     aim.sol[:glb] = 4.56
 end
 
+
+function build_discrete_model(aim::MyAbstractInfrastructureModel)
+    for nw in nw_ids(aim)
+        c = var(aim, nw)[:c] = JuMP.@variable(aim.model,
+            [i in ids(aim, nw, :comp)], base_name="$(nw)_c",
+            integer=true,
+            lower_bound = i*2
+        )
+        sol_component_value(aim, nw, :comp, :c, ids(aim, nw, :comp), c)
+    end
+
+    for nw in nw_ids(aim)
+        for (c,comp) in ref(aim, nw, :comp)
+            JuMP.@constraint(aim.model, var(aim, nw, :c, c) >= c/2)
+        end
+    end
+
+    JuMP.@objective(aim.model, Min, sum(
+        sum( var(aim, nw, :c, c)^2 for c in ids(aim, nw, :comp))
+        for nw in nw_ids(aim))
+    )
+end
+
+
 function ref_add_core!(ref::Dict)
     for (nw, nw_ref) in ref[:nw]
         nw_ref[:comp] = Dict(x for x in nw_ref[:comp] if (!haskey(x.second, "status") || x.second["status"] != 0))
@@ -218,7 +242,7 @@ end
 
 @testset "helper functions - instantiate_model, optimize_model!, sol" begin
     mim = instantiate_model(generic_network_data, MyInfrastructureModel, build_my_model, ref_add_core!, gn_global_keys, ref_extensions=[ref_ext_comp_stat!])
-    result = optimize_model!(mim, optimizer=ipopt_solver)
+    result = optimize_model!(mim, relax_integrality=true, optimizer=ipopt_solver)
     solution = result["solution"]
 
     @test solution["glb"] == 4.56
@@ -258,6 +282,16 @@ end
         @test nw_sol["comp"]["3"]["d"] == 1.23
     end
 end
+
+@testset "helper functions - relax_integrality" begin
+    mim = instantiate_model(generic_network_data, MyInfrastructureModel, build_discrete_model, ref_add_core!, gn_global_keys)
+    result = optimize_model!(mim, relax_integrality=true, optimizer=ipopt_solver)
+    solution = result["solution"]
+
+    @test isapprox(solution["comp"]["1"]["c"], 2.0)
+    @test isapprox(solution["comp"]["3"]["c"], 6.0)
+end
+
 
 
 @testset "build_result structure" begin


### PR DESCRIPTION
JuMP v0.21.4 restored a popular feature that lets you automatically relax the integrality requirements of a JuMP model, details [here](https://github.com/jump-dev/JuMP.jl/issues/1611).

I find this to be a convenient feature in many contexts including users who use "run" methods as black-boxes, so I propose to expose it to users through all IM packages. This PR adds support at the IM level via `optimize_model!` downstream packages will also have to make a very minor update their generic `run_model(...)` method to expose the feature to users.

Thoughts or objections @rb004f @tasseff @pseudocubic @kaarthiksundar?