### PR TITLE
Make MATLAB's quote escaping more robust

### DIFF
--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -215,49 +215,77 @@ function _parse_matlab_data(lines, index, start_char, end_char)
     return matrix_dict
 end
 
-const single_quote_expr = r"\'((\\.|[^\'])*?)\'"
-
 ""
 function split_line(mp_line::AbstractString)
-    if occursin(single_quote_expr, mp_line)
-        # splits a string on white space while escaping text quoted with "'"
-        # note that quotes will be stripped later, when data typing occurs
+    tokens = []
+    curr_token = ""
+    is_curr_token_quote = false
 
-        #println(mp_line)
-        tokens = []
-        while length(mp_line) > 0 && occursin(single_quote_expr, mp_line)
-            #println(mp_line)
-            m = match(single_quote_expr, mp_line)
+    isquote(c) = (c == '\'' || c == '"')
 
-            if m.offset > 1
-                push!(tokens, mp_line[1:m.offset-1])
-            end
-            push!(tokens, replace(m.match, "\\'" => "'")) # replace escaped quotes
-
-            mp_line = mp_line[m.offset+length(m.match):end]
+    function _push_curr_token()
+        if curr_pos <= length(mp_line)
+            curr_token *= mp_line[curr_pos]
         end
-        if length(mp_line) > 0
-            push!(tokens, mp_line)
+        curr_token = strip(curr_token)
+        if length(curr_token) > 0
+            push!(tokens, curr_token)
         end
-        #println(tokens)
-
-        items = []
-        for token in tokens
-            if occursin("'",token)
-                push!(items, strip(token))
-            else
-                for parts in split(token)
-                    push!(items, strip(parts))
-                end
-            end
-        end
-        #println(items)
-
-        #return [strip(mp_line, '\'')]
-        return items
-    else
-        return split(mp_line)
+        curr_token = ""
+        curr_pos += 1
+        is_curr_token_quote = false
     end
+
+    function _push_curr_char()
+        curr_token *= mp_line[curr_pos]
+        curr_pos += 1
+    end
+
+    curr_pos = 1
+    while curr_pos <= length(mp_line)
+        if is_curr_token_quote
+            if mp_line[curr_pos] == curr_token[1]
+                if mp_line[curr_pos-1] == '\\'
+                    # If we are inside a quote and we see slash-quote, we should
+                    # treat the quote character as a regular character.
+                    _push_curr_char()
+                elseif curr_pos < length(mp_line) && mp_line[curr_pos+1] == curr_token[1]
+                    # If we are inside a quote, and we see two quotes in a row,
+                    # we should append one of the quotes to the current
+                    # token, then skip the other one.
+                    curr_token *= mp_line[curr_pos]
+                    curr_pos += 2
+                else
+                    # If we are inside a quote, and we see an unescaped quote char,
+                    # then the quote is ending. We should push the current token.
+                    _push_curr_token()
+                end
+            else
+                # If we are inside a quote and we see a non-quote character,
+                # we should append that character to the current token.
+                _push_curr_char()
+            end
+        else
+            if isspace(mp_line[curr_pos]) && !isspace(mp_line[curr_pos+1])
+                # If we are not inside a quote and we see a transition from
+                # space to non-space character, then the current token is done.
+                _push_curr_token()
+            elseif isquote(mp_line[curr_pos])
+                # If we are not inside a quote and we see a quote character,
+                # then a new quote is starting. We should append the quote
+                # character to the current token and switch to quote mode.
+                curr_token = strip(curr_token * mp_line[curr_pos])
+                is_curr_token_quote = true
+                curr_pos += 1
+            else
+                # If we are not inside a quote and we see a regular character,
+                # we should append that character to the current token.
+                _push_curr_char()
+            end
+        end
+    end
+    _push_curr_token()
+    return tokens
 end
 
 ""

--- a/test/data.jl
+++ b/test/data.jl
@@ -51,6 +51,22 @@
         @test isa(data["bloop.baseMVA"], Float64)
     end
 
+    @testset "parsing matlab quotes" begin
+        # Single quotes
+        @test split_line("''") == ["''"]
+        @test split_line("'Slack Bus'") == ["'Slack Bus'"]
+        @test split_line("'Slack ''Bus'''") == ["'Slack 'Bus''"]
+        @test split_line("'''''Slack Bus'''''") == ["'''Slack Bus'''"]
+
+        # Double quotes
+        @test split_line("\"\"\"Slack Bus\"\"\"") == ["\"\"Slack Bus\"\""]
+        @test split_line("\"Slack \\\"Bus\\\"\"") == ["\"Slack \\\"Bus\\\"\""]
+
+        # In .m file
+        data = parse_matlab_file("../test/data/matlab_04.m")
+        @test length(data["mpc.names"]) == 4
+    end
+
     @testset "parsing matlab extended features" begin
         data, func, columns = parse_matlab_file("../test/data/matlab_02.m", extended=true)
 

--- a/test/data/matlab_04.m
+++ b/test/data/matlab_04.m
@@ -1,0 +1,10 @@
+% case to test matlab quotes
+
+function mpc = matlab_04
+
+mpc.names = {
+	'Slack Bus 1'
+	'Slack \"Bus\" 1'
+	'Slack '''
+	''
+};


### PR DESCRIPTION
Hi Carleton, thank you for your work on this package and on PowerModels.jl!

InfrastructureModels.jl provides the (very useful) `parse_matlab_file` function, but this function is currently unable to handle some valid ways to escape quote characters in MATLAB. Two single quotes in a row, in particular, are not currently supported. Because of this, loading [Texas A&M Midwest24K](https://electricgrids.engr.tamu.edu/electric-grid-test-cases/datasets-for-arpa-e-perform-program/) generates the following error:

```
julia> using InfrastructureModels
julia> case = parse_matlab_file("Midwest24k.m")

matrix parsing error, inconsistent number of items in each row
 'O''Brien Wind 1'

Stacktrace:
  [1] error(logger::Memento.Logger, msg::String)
    @ Memento ~/.julia/packages/Memento/IanT6/src/loggers.jl:437
  [2] _parse_matlab_data(lines::Vector{SubString{String}}, index::Int64, start_char::Char, end_char::Char)
    @ InfrastructureModels ~/Packages/InfrastructureModels.jl/src/io/matlab.jl:184
  [3] _parse_matlab_cells(lines::Vector{SubString{String}}, index::Int64)
    @ InfrastructureModels ~/Packages/InfrastructureModels.jl/src/io/matlab.jl:120
  [4] parse_matlab_string(data_string::String; extended::Bool)
    @ InfrastructureModels ~/Packages/InfrastructureModels.jl/src/io/matlab.jl:50
  [5] parse_matlab_string
    @ ~/Packages/InfrastructureModels.jl/src/io/matlab.jl:15 [inlined]
  [6] #parse_matlab_file#62
    @ ~/Packages/InfrastructureModels.jl/src/io/matlab.jl:11 [inlined]
  [7] parse_matlab_file(file_string::String)
    @ InfrastructureModels ~/Packages/InfrastructureModels.jl/src/io/matlab.jl:10
  [8] top-level scope
    @ In[1]:2
  [9] eval
    @ ./boot.jl:360 [inlined]
 [10] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:1094
```

This pull request rewrites the `split_line` function to make escaping more robust. After the patch is applied, Texas A&M Midwest24K, for example, loads correctly (see below). Other forms of escaping (such as two double quotes in a row) are also now supported.
```
julia> using InfrastructureModels
julia> case = parse_matlab_file("Midwest24k.m")

Dict{String, Any} with 9 entries:
  "mpc.bus"      => Any[Real[110001, 1, 0.0, 0.0, 0.0, 0.0, 1, 1.00471, -54.657…
  "mpc.version"  => "2"
  "mpc.baseMVA"  => 100.0
  "mpc.gencost"  => Any[Real[1, 0, 0, 6, 12.38, 0.0, 15.5, 0.0, 18.63, 0.0, 21.…
  "mpc.bus_name" => Any[SubString{String}["MARION 1 1"], SubString{String}["MAR…
  "mpc.gentype"  => Any[SubString{String}["HY"], SubString{String}["HY"], SubSt…
  "mpc.gen"      => Any[Real[110864, 0.0, 0.0, 13.56, -16.8, 1.0, 33.6, 0, 28.0…
  "mpc.branch"   => Any[Real[110002, 110001, 0.00342, 0.12246, 0.0, 139.4, 139.…
  "mpc.genfuel"  => Any[SubString{String}["hydro"], SubString{String}["hydro"],…
```