### PR TITLE
Remove Memento and add support for Logging.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ InfrastructureModels.jl Change Log
 
 ### Staged
 - Various maintenance updates to bring InfrastructureModels up to date (#97)
+- Remove Memento and switch to Logging.jl (#99)
 
 ### v0.7.8
 - Fix support for strongly typed network data (#92)

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "InfrastructureModels"
 uuid = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
+version = "0.7.8"
 authors = ["Carleton Coffrin"]
 repo = "https://github.com/lanl-ansi/InfrastructureModels.jl"
-version = "0.7.8"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 ECOS = "1"
@@ -14,7 +14,7 @@ Ipopt = "1"
 JSON = "0.21, 1"
 JuMP = "1"
 Juniper = "0.8, 0.9"
-Memento = "1"
+Logging = "1.10"
 julia = "1.10"
 
 [extras]

--- a/src/InfrastructureModels.jl
+++ b/src/InfrastructureModels.jl
@@ -1,28 +1,16 @@
 module InfrastructureModels
 
 import JuMP
-import Memento
+import Logging
 
-# Create our module level logger (this will get precompiled)
-const _LOGGER = Memento.getlogger(@__MODULE__)
-
-# Register the module level logger at runtime so that folks can access the logger via `getlogger(InfrastructureModels)`
-# NOTE: If this line is not included then the precompiled `Infrastructure.LOGGER` won't be registered at runtime.
-__init__() = Memento.register(_LOGGER)
-
-"Suppresses information and warning messages output by InfrastructureModels, for fine grained control use the Memento package"
-function silence()
-    Memento.info(_LOGGER, "Suppressing information and warning messages for the rest of this session.  Use the Memento package for more fine-grained control of logging.")
-    Memento.setlevel!(_LOGGER, "error")
-end
-
-"alows the user to set the logging level without the need to add Memento"
-function logger_config!(level; kwargs...)
-    Memento.config!(_LOGGER, level, kwargs...)
+function __init__()
+    logger_config!("info")
+    return
 end
 
 const nw_id_default = 0
 
+include("core/logging.jl")
 include("core/base.jl")
 include("core/data.jl")
 include("core/constraint.jl")

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -190,7 +190,7 @@ function _populate_ref_it!(refs::Dict{Symbol, <:Any}, data_it::Dict{String, <:An
     # Build a multinetwork representation of the data.
     if ismultinetwork(data_it)
         nws_data = data_it["nw"]
-    
+
         for (key, item) in data_it
             if key != "nw"
                 refs[:it][Symbol(it)][Symbol(key)] = item
@@ -206,7 +206,7 @@ function _populate_ref_it!(refs::Dict{Symbol, <:Any}, data_it::Dict{String, <:An
     for (n, nw_data) in nws_data
         nw_id = parse(Int, n)
         ref = nws[nw_id] = Dict{Symbol, Any}()
-    
+
         for (key, item) in nw_data
             if !(key in global_keys)
                 if typeof(item) <: Dict{String, <:Any} && _iscomponentdict(item)
@@ -322,12 +322,12 @@ end
 function instantiate_model(
     data::Dict{String,<:Any}, model_type::Type, build_method, ref_add_core!,
     global_keys::Set{String}; ref_extensions=[], kwargs...)
-    # NOTE, this model constructor will build the ref dict using the latest info from the data    
+    # NOTE, this model constructor will build the ref dict using the latest info from the data
     start_time = time()
 
     imo = InitializeInfrastructureModel(model_type, data, global_keys; kwargs...)
 
-    Memento.debug(_LOGGER, "initialize model time: $(time() - start_time)")
+    @_debug("initialize model time: $(time() - start_time)")
 
     start_time = time()
     ref_add_core!(imo.ref)
@@ -336,11 +336,11 @@ function instantiate_model(
         ref_ext!(imo.ref, imo.data)
     end
 
-    Memento.debug(_LOGGER, "build ref time: $(time() - start_time)")
+    @_debug("build ref time: $(time() - start_time)")
 
     start_time = time()
     build_method(imo)
-    Memento.debug(_LOGGER, "build method time: $(time() - start_time)")
+    @_debug("build method time: $(time() - start_time)")
 
     return imo
 end
@@ -350,12 +350,12 @@ end
 function instantiate_model(
     data::Dict{String,<:Any}, model_type::Type, build_method, ref_add_core!,
     global_keys::Set{String}, it::Symbol; ref_extensions=[], kwargs...)
-    # NOTE, this model constructor will build the ref dict using the latest info from the data    
+    # NOTE, this model constructor will build the ref dict using the latest info from the data
     start_time = time()
 
     imo = InitializeInfrastructureModel(model_type, data, global_keys, it; kwargs...)
 
-    Memento.debug(_LOGGER, "initialize model time: $(time() - start_time)")
+    @_debug("initialize model time: $(time() - start_time)")
 
     start_time = time()
     ref_add_core!(imo.ref)
@@ -364,11 +364,11 @@ function instantiate_model(
         ref_ext!(imo.ref, imo.data)
     end
 
-    Memento.debug(_LOGGER, "build ref time: $(time() - start_time)")
+    @_debug("build ref time: $(time() - start_time)")
 
     start_time = time()
     build_method(imo)
-    Memento.debug(_LOGGER, "build method time: $(time() - start_time)")
+    @_debug("build method time: $(time() - start_time)")
 
     return imo
 end
@@ -386,12 +386,12 @@ function optimize_model!(aim::AbstractInfrastructureModel; relax_integrality=fal
         if JuMP.backend(aim.model).optimizer === nothing
             JuMP.set_optimizer(aim.model, optimizer)
         else
-            Memento.warn(_LOGGER, "Model already contains optimizer, cannot use optimizer specified in `optimize_model!`")
+            @_warn("Model already contains optimizer, cannot use optimizer specified in `optimize_model!`")
         end
     end
 
     if JuMP.mode(aim.model) != JuMP.DIRECT && JuMP.backend(aim.model).optimizer === nothing
-        Memento.error(_LOGGER, "No optimizer specified in `optimize_model!` or the given JuMP model.")
+        @_error("No optimizer specified in `optimize_model!` or the given JuMP model.")
     end
 
     _, solve_time, solve_bytes_alloc, sec_in_gc = @timed JuMP.optimize!(aim.model)
@@ -399,14 +399,14 @@ function optimize_model!(aim::AbstractInfrastructureModel; relax_integrality=fal
     try
         solve_time = JuMP.solve_time(aim.model)
     catch
-        Memento.warn(_LOGGER, "The given optimizer does not provide the SolveTime() attribute, falling back on @timed.  This is not a rigorous timing value.");
+        @_warn("The given optimizer does not provide the SolveTime() attribute, falling back on @timed.  This is not a rigorous timing value.");
     end
-    
-    Memento.debug(_LOGGER, "JuMP model optimize time: $(time() - start_time)")
+
+    @_debug("JuMP model optimize time: $(time() - start_time)")
 
     start_time = time()
     result = build_result(aim, solve_time; solution_processors=solution_processors)
-    Memento.debug(_LOGGER, "solution build time: $(time() - start_time)")
+    @_debug("solution build time: $(time() - start_time)")
 
     aim.solution = result["solution"]
 

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -2,10 +2,10 @@
 function update_data!(data::Dict{String,<:Any}, new_data::Dict{String,<:Any})
     if haskey(data, "per_unit") && haskey(new_data, "per_unit")
         if data["per_unit"] != new_data["per_unit"]
-            Memento.error(_LOGGER, "update_data requires datasets in the same units, try make_per_unit and make_mixed_units")
+            @_error("update_data requires datasets in the same units, try make_per_unit and make_mixed_units")
         end
     else
-        Memento.warn(_LOGGER, "running update_data with data that does not include per_unit field, units may be incorrect")
+        @_warn("running update_data with data that does not include per_unit field, units may be incorrect")
     end
 
     _update_data!(data, new_data)
@@ -101,7 +101,7 @@ end
 function replicate(sn_data::Dict{String,<:Any}, count::Int, global_keys::Set{String})
     @assert count > 0
     if ismultinetwork(sn_data)
-        Memento.error(_LOGGER, "replicate can only be used on single networks")
+        @_error("replicate can only be used on single networks")
     end
 
     name = get(sn_data, "name", "anonymous")
@@ -137,17 +137,17 @@ function make_multinetwork(data::Dict{String, <:Any}, it::String, global_keys::S
     data_it = ismultiinfrastructure(data) ? data["it"][it] : data
 
     if InfrastructureModels.ismultinetwork(data_it)
-        Memento.error(_LOGGER, "make_multinetwork does not support multinetwork data")
+        @_error("make_multinetwork does not support multinetwork data")
     end
 
     if !haskey(data_it, "time_series")
-        Memento.error(_LOGGER, "make_multinetwork requires time_series data")
+        @_error("make_multinetwork requires time_series data")
     end
 
     steps = data_it["time_series"]["num_steps"]
 
     if !isa(steps, Int)
-        Memento.error(_LOGGER, "the value of num_steps should be an integer, given $(steps)")
+        @_error("the value of num_steps should be an integer, given $(steps)")
     end
 
     mn_data = replicate(data_it, steps, union(global_keys, Set(["time_series"])))
@@ -161,16 +161,16 @@ function make_multinetwork(data::Dict{String, <:Any}, it::String, global_keys::S
             if isa(v, Dict) && haskey(nw_data, k)
                 #println(k); println(v)
                 _update_data_timepoint!(nw_data[k], v, i)
-            elseif isa(v, Array) 
-                if length(v) != steps 
-                    Memento.error(_LOGGER, "the size of the array $k in the time series block must be equal to $steps, currently it is $(length(v))")
-                else 
+            elseif isa(v, Array)
+                if length(v) != steps
+                    @_error("the size of the array $k in the time series block must be equal to $steps, currently it is $(length(v))")
+                else
                     #println(k); println(v[i])
                     nw_data[k] = v[i]
-                end 
+                end
             else
                 mn_data[k] = v
-            end 
+            end
         end
     end
 
@@ -183,15 +183,15 @@ end
 "loads a single time point from a time_series data block into the current network"
 function load_timepoint!(data::Dict{String, <:Any}, step_index::Int)
     if InfrastructureModels.ismultinetwork(data)
-        Memento.error(_LOGGER, "load_timepoint! does not support multinetwork data")
+        @_error("load_timepoint! does not support multinetwork data")
     end
 
     if !haskey(data, "time_series")
-        Memento.error(_LOGGER, "load_timepoint! requires time_series data")
+        @_error("load_timepoint! requires time_series data")
     end
 
     if step_index < 1 || step_index > data["time_series"]["num_steps"]
-        Memento.error(_LOGGER, "a step index of $(step_index) is outside the valid range of 1:$(data["time_series"]["num_steps"])")
+        @_error("a step index of $(step_index) is outside the valid range of 1:$(data["time_series"]["num_steps"])")
     end
 
     for (k,v) in data["time_series"]
@@ -215,10 +215,10 @@ function _update_data_timepoint!(data::Dict{String, <:Any}, new_data::Dict{Strin
             elseif (!isa(v, Dict) || !isa(v, Array)) && isa(new_v, Array)
                 data[key] = new_v[step]
             else
-                Memento.warn(_LOGGER, "skipping key $(key) because object types do not match, target $(typeof(v)) source $(typeof(new_v))")
+                @_warn("skipping key $(key) because object types do not match, target $(typeof(v)) source $(typeof(new_v))")
             end
         else
-            Memento.warn(_LOGGER, "skipping time_series key $(key) because it does not occur in the target data")
+            @_warn("skipping time_series key $(key) because it does not occur in the target data")
         end
     end
 end
@@ -239,7 +239,7 @@ component_table(data::Dict{String,<:Any}, component::String, field::String) = co
 function _component_table(data::Dict{String,<:Any}, component::String, fields::Vector{String})
     comps = data[component]
     if !_iscomponentdict(comps)
-        Memento.error(_LOGGER, "$(component) does not appear to refer to a component list")
+        @_error("$(component) does not appear to refer to a component list")
     end
 
     items = []
@@ -277,7 +277,7 @@ function summary(io::IO, data::Dict{String,<:Any};
     )
 
     if ismultinetwork(data)
-        Memento.error(_LOGGER, "summary does not yet support multinetwork data")
+        @_error("summary does not yet support multinetwork data")
     end
 
     component_types = []
@@ -298,7 +298,7 @@ function summary(io::IO, data::Dict{String,<:Any};
         println(io, "")
         println(io, _bold("Table Counts"))
     end
-    
+
     for k in sort(component_types, by=x->get(component_types_order, x, max_parameter_value))
         println(io, "  $(k): $(length(data[k]))")
     end

--- a/src/core/logging.jl
+++ b/src/core/logging.jl
@@ -1,0 +1,56 @@
+const _LOGGER = Ref{Logging.ConsoleLogger}()
+
+"""
+    silence()
+
+Silence logging within InfrastructureModels.
+
+This is equivalent to calling `logger_config!("error")`.
+"""
+silence() = logger_config!("error")
+
+function _meta_formatter(level::Logging.LogLevel, _module, args...)
+    return Logging.default_logcolor(level), "$(_module) | $level]:", ""
+end
+
+function logger_config!(level::Logging.LogLevel)
+    _LOGGER[] =
+        Logging.ConsoleLogger(stdout, level; meta_formatter = _meta_formatter)
+    return
+end
+
+"""
+    logger_config!(level::String)
+
+Set the logging level within PowerModels. `level` must be one of `"error"`,
+`"warn"`, `"info"`, or `"debug"`.
+"""
+function logger_config!(level::String)
+    return getfield(Logging, level |> titlecase |> Symbol) |> logger_config!
+end
+
+function _log_if_level(f, level, logger = _LOGGER[])
+    if level >= Logging.min_enabled_level(logger)
+        Logging.with_logger(f, logger)
+    end
+    return
+end
+
+macro _error(msg)
+    return quote
+        $_log_if_level(() -> @error($msg), $(Logging.Error))
+        error($msg)
+    end |> esc
+end
+
+macro _warn(msg)
+    return :($_log_if_level(() -> @warn($msg), $(Logging.Warn)) )|> esc
+end
+
+macro _debug(msg)
+    return :($_log_if_level(() -> @debug($msg), $(Logging.Debug))) |> esc
+end
+
+macro _info(msg)
+    return :($_log_if_level(() -> @info($msg), $(Logging.Info)) )|> esc
+end

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -5,7 +5,7 @@ function build_result(aim::AbstractInfrastructureModel, solve_time; solution_pro
     try
         result_count = JuMP.result_count(aim.model)
     catch
-        Memento.warn(_LOGGER, "the given optimizer does not provide the ResultCount() attribute, assuming the solver returned a solution which may be incorrect.");
+        @_warn("the given optimizer does not provide the ResultCount() attribute, assuming the solver returned a solution which may be incorrect.");
     end
 
     solution = Dict{String,Any}()
@@ -13,7 +13,7 @@ function build_result(aim::AbstractInfrastructureModel, solve_time; solution_pro
     if result_count > 0
         solution = build_solution(aim, post_processors=solution_processors)
     else
-        Memento.warn(_LOGGER, "model has no results, solution cannot be built")
+        @_warn("model has no results, solution cannot be built")
     end
 
     result = Dict{String,Any}(
@@ -166,7 +166,7 @@ end
 
 ""
 function build_solution_values(var::Any)
-    Memento.warn(_LOGGER, "build_solution_values found unknown type $(typeof(var))")
+    @_warn("build_solution_values found unknown type $(typeof(var))")
     return var
 end
 

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -17,7 +17,7 @@ function arrays_to_dicts!(data::Dict{String,<:Any})
                 if !(haskey(dict, key))
                     dict[key] = item
                 else
-                    Memento.warn(_LOGGER, "skipping component $(item["index"]) from the $(k) table because a component with the same id already exists")
+                    @_warn("skipping component $(item["index"]) from the $(k) table because a component with the same id already exists")
                 end
             end
             data[k] = dict

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -36,7 +36,7 @@ function parse_matlab_string(data_string::String; extended=false)
             function_name = value
         elseif occursin("=",line)
             if struct_name !== nothing && !occursin("$(struct_name).", line)
-                Memento.warn(_LOGGER, "assignments are expected to be made to \"$(struct_name)\" but given: $(line)")
+                @_warn("assignments are expected to be made to \"$(struct_name)\" but given: $(line)")
             end
 
             if occursin("[", line)
@@ -59,7 +59,7 @@ function parse_matlab_string(data_string::String; extended=false)
                 matlab_dict[name] = value
             end
         else
-            Memento.warn(_LOGGER, "Matlab parser skipping the following line:\n  $(line)")
+            @_warn("Matlab parser skipping the following line:\n  $(line)")
         end
 
         index += 1
@@ -181,7 +181,7 @@ function _parse_matlab_data(lines, index, start_char, end_char)
         if columns < 0
             columns = length(row_items)
         elseif columns != length(row_items)
-            Memento.error(_LOGGER, "matrix parsing error, inconsistent number of items in each row\n$(row)")
+            @_error("matrix parsing error, inconsistent number of items in each row\n$(row)")
         end
     end
 
@@ -199,13 +199,13 @@ function _parse_matlab_data(lines, index, start_char, end_char)
         column_names_string = replace(column_names_string, "%column_names%" => "")
         column_names = split(column_names_string)
         if length(matrix[1]) != length(column_names)
-            Memento.error(_LOGGER, "column name parsing error, data rows $(length(matrix[1])), column names $(length(column_names)) \n$(column_names)")
+            @_error("column name parsing error, data rows $(length(matrix[1])), column names $(length(column_names)) \n$(column_names)")
         end
         for (c, column_name) in enumerate(column_names)
             if column_name == "index"
-                Memento.info(_LOGGER, "the column named \"index\" in matrix will be interpreted as a unique component identifier")
+                @_info("the column named \"index\" in matrix will be interpreted as a unique component identifier")
                 if !(typeof(typed_columns[c][1]) <: Int)
-                    Memento.error(_LOGGER, "the type of a column named \"index\" must be Int, but given $(typeof(typed_columns[c][1]))")
+                    @_error("the type of a column named \"index\" must be Int, but given $(typeof(typed_columns[c][1]))")
                 end
             end
         end
@@ -319,7 +319,7 @@ function check_type(typ, value)
             value = parse(typ, value)
             return value
         catch e
-            Memento.error(_LOGGER, "parsing error, the matlab string \"$(value)\" can not be parsed to $(typ) data")
+            @_error("parsing error, the matlab string \"$(value)\" can not be parsed to $(typ) data")
             rethrow(e)
         end
     else
@@ -327,7 +327,7 @@ function check_type(typ, value)
             value = typ(value)
             return value
         catch e
-            Memento.error(_LOGGER, "parsing error, the matlab value $(value) of type $(typeof(value)) can not be parsed to $(typ) data")
+            @_error("parsing error, the matlab value $(value) of type $(typeof(value)) can not be parsed to $(typ) data")
             rethrow(e)
         end
     end

--- a/test/base.jl
+++ b/test/base.jl
@@ -9,16 +9,6 @@ abstract type AbstractModel end
 mutable struct FooModel <: AbstractModel @some_fields end
 mutable struct BarModel <: AbstractModel @some_fields end
 
-
-@testset "silence" begin
-    # This should silence everything except error messages.
-    InfrastructureModels.silence()
-    im_logger = Memento.getlogger(InfrastructureModels)
-    @test Memento.getlevel(im_logger) == "error"
-    Memento.warn(im_logger, "Silenced message should not be displayed.")
-end
-
-
 @testset "def macro" begin
     foo = FooModel(1, 2.3, "4")
     bar = BarModel(1, 2.3, "4")

--- a/test/base.jl
+++ b/test/base.jl
@@ -448,3 +448,15 @@ end
     @test result["primal_status"] == JuMP.FEASIBLE_POINT
     @test result["dual_status"] == JuMP.FEASIBLE_POINT
 end
+
+@testset "test_logging" begin
+    InfrastructureModels.logger_config!("debug")
+    InfrastructureModels.@_debug("test-debug")
+    InfrastructureModels.@_info("test-info")
+    InfrastructureModels.@_warn("test-warn")
+    @test_throws(
+        ErrorException("test-error"),
+        InfrastructureModels.@_error("test-error"),
+    )
+    InfrastructureModels.silence()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,23 +1,19 @@
 using InfrastructureModels
-import Memento
-import JSON
+using Test
 
-import JuMP
-
-import Ipopt
 import ECOS
+import Ipopt
+import JSON
+import JuMP
 import Juniper
+import Random: seed!
+
+# Suppress warnings during testing
+InfrastructureModels.silence()
 
 ipopt_solver = JuMP.optimizer_with_attributes(Ipopt.Optimizer, "print_level"=>0)
 ecos_solver = JuMP.optimizer_with_attributes(ECOS.Optimizer, "verbose"=>0)
 juniper_solver = JuMP.optimizer_with_attributes(Juniper.Optimizer, "nl_solver"=>ipopt_solver, "log_levels"=>[])
-
-import Random: seed!
-
-using Test
-
-# Suppress warnings during testing
-InfrastructureModels.logger_config!("error")
 
 include("common.jl")
 


### PR DESCRIPTION
Closes #98

This PR removes Memento in favour of the Logging.jl standard library. The API for `silence!` and `logger_config!` are unchanged.

There is a new file `src/core/logging.jl` which contains the logic for logging.

Throughout the rest of the package, the changes are:

* `Memento.error(_LOGGER, ` becomes `@_error(`
* `Memento.warn(_LOGGER, ` becomes `@_warn(`
* `Memento.info(_LOGGER, ` becomes `@_info(`
* `Memento.debug(_LOGGER, ` becomes `@_debug(`

The benefit of this approach is that it is self-contained and backward compatible within a package. It doesn't require the entire InfrastructureModels ecosystem to move as one from Memento to Logging.jl.

We looked into other ways of writing the logger, https://github.com/lanl-ansi/InfrastructureModels.jl/pull/98, https://github.com/lanl-ansi/PowerModels.jl/pull/997 before ultimately deciding on this approach.

We also investigated updating Memento, but it commits type-piracy on this macro: https://github.com/invenia/Memento.jl/blob/58a92c6d688a5372e04c3d05c6da7a0cf3430a94/src/memento_test.jl#L119

We'd likely need to remove it, or rename it to something like `@memento_test_throws`. This would be a breaking change that we'd need to update every InfrastructureModels package for any way, so we might as well bite the bullet and remove it as a dependency. This should save us from any future issues in the long term.

## PowerModelsDistribution

Our approach is different to PMD:

https://github.com/lanl-ansi/PowerModelsDistribution.jl/blob/main/src/core/logging.jl

They muck with the global logger, which would affect _all_ packages using logging. As a single package it's okay. And it doesn't conflict with the approach taken in this PR. But the logic is not correct if multiple packages adopted the logging style of PowerModelsDistribution. Here's an example of where things can go wrong: https://github.com/lanl-ansi/PowerModels.jl/pull/997#issuecomment-4211555962 (Changing the logger mutates global state; multiple packages modifying the same global state can get into issues.)

## Other PRs

 - PowerModels: https://github.com/lanl-ansi/PowerModels.jl/pull/1000
 - GasModels: https://github.com/lanl-ansi/GasModels.jl/pull/304